### PR TITLE
Improve List Router

### DIFF
--- a/backend/sources/routers/form_router.py
+++ b/backend/sources/routers/form_router.py
@@ -106,6 +106,10 @@ async def create_form(request: Request, form: smart_forms_types.FormDescription)
 class ListFormReceiveModel(BaseModel):
     offset: int
     count: int
+    # If isOnwer is true, then only shows forms owned by the user.
+    # If isOnwer is false, only shows public editable forms, INCLUDING
+    # the forms owned by the user.
+    isOnwer: bool
 
 class ListFormReturnModel(BaseModel):
     forms: List[smart_forms_types.FormDescription]
@@ -129,16 +133,20 @@ class ListFormReturnModel(BaseModel):
 )
 async def get_forms_list(request: Request, params: ListFormReceiveModel):
     """
-        Returns the list of all available forms, made by the user.
-        If the user is not signed in, then all forms are returned.
+        Returns the list of all available forms.
+        If isOnwer is true, then only forms created by the user will be displayed.
     """
     # if authentication is enabled, just return forms made by the authenticated user
     db_search_params = {}
     if routers.AUTHENTICATION_CHECKS:
-        if request.session.get("user") is None:
+        if request.session.get("user") is None and params.isOnwer:
             return PlainTextResponse("User isn't signed in.", status_code=202)
-        else:
+        elif params.isOnwer:
+            # get forms we own
             db_search_params["authorEmail"] = request.session.get("user")["email"]
+        else:
+            # only get forms that can be filled online
+            db_search_params["canBeFilledOnline"] = True
     
     db = database.get_collection(database.FORMS)
 

--- a/backend/sources/tests/unit/test_routers/test_form_router.py
+++ b/backend/sources/tests/unit/test_routers/test_form_router.py
@@ -99,7 +99,8 @@ class TestFormEndpointNoAuthChecks(unittest.TestCase):
             f"/api/form/list",
             json={
                 "offset": 0,
-                "count": 10
+                "count": 10,
+                "isOnwer": False,
             }
         )
 


### PR DESCRIPTION
This closes #44.

I added the `isOwner` field on the parameters given to the list function.

The user can now select the "public" forms, which can be edited online by anybody, and the "private" forms, e.g. his/her own forms.

Note that some of the public forms still need the user to be signed in to submit. 