### PR TITLE
Add Date and Time to Forms&Entries

### DIFF
--- a/backend/sources/routers/entry_router.py
+++ b/backend/sources/routers/entry_router.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import random
 from typing import List
 from fastapi import APIRouter, File, Request
@@ -59,9 +60,10 @@ async def submit_entry(request: Request, entry: smart_forms_types.FormAnswer):
     except:
         return PlainTextResponse(f"Unable to find form {form_id} in our database.", 201)
     
-    # set email
+    # set email and time
     entry.authorEmail = user_email
-
+    entry.creationDate = datetime.now()
+    
     # user needs to be signed in to submit the form
     if form.description.needsToBeSignedInToSubmit and user_email == "":
         return PlainTextResponse("The user needs to be authenticated to submit to this form.", 202)
@@ -196,11 +198,12 @@ async def edit_entry(request: Request, entry: smart_forms_types.FormAnswer):
     if entry.formId != form.description.formId:
         return PlainTextResponse("Entry can't change its formId.", 400)
 
-    entry.authorEmail = entry_db.authorEmail
+    entry_db.answers = entry.answers
+    entry_db.creationDate = datetime.now()
 
     db = database.get_collection(database.ENTRIES)
     # TODO: Check what is here.
-    db.replace_one({ "answerId": entry.answerId }, entry.to_dict())
+    db.replace_one({ "answerId": entry.answerId }, entry_db.to_dict())
     return PlainTextResponse("Ok")
 
 

--- a/backend/sources/routers/form_router.py
+++ b/backend/sources/routers/form_router.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 from fastapi import APIRouter, Response
 from fastapi.responses import PlainTextResponse
@@ -92,6 +93,8 @@ async def create_form(request: Request, form: smart_forms_types.FormDescription)
         # when creating a form, we manually set the formID to be empty, to avoid
         # collisions.
         form.formId = str(random.randint(10**10, 10**11))
+        form.creationDate = datetime.now()
+        
         model = pdf_processor.create_form_from_description(form, False)
         database.get_collection(database.FORMS).insert_one(model.to_dict())
         resp = CreateFormReturnModel(

--- a/backend/sources/routers/inference_router.py
+++ b/backend/sources/routers/inference_router.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import random
 from typing import List, Union
@@ -87,6 +88,7 @@ async def extract_answer(request: Request, fileUploads: List[UploadFile] = File(
     # set ids
     for answer in answers:
         answer.answerId = f"entry-{str(random.randint(10**10, 9*10**10))}"
+        answer.creationDate = datetime.now()
 
     # if we have any entries, add them to the DB
     if answers != []:

--- a/backend/sources/smart_forms_types/models.py
+++ b/backend/sources/smart_forms_types/models.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import List, Optional, Union
 from pydantic import BaseModel
 import pickle
+from datetime import datetime
+
 class FormTextQuestion(BaseModel):
     """
         Stores a single text question.
@@ -31,6 +33,7 @@ class FormDescription(BaseModel):
     canBeFilledOnline: bool
     needsToBeSignedInToSubmit: bool
     authorEmail: Optional[str] = ""
+    creationDate: Optional[datetime]
 
 class FormAnswer(BaseModel):
     """
@@ -42,6 +45,7 @@ class FormAnswer(BaseModel):
     # signed user, if signed in.
     authorEmail: Optional[str] = ""
     answers: List[str]
+    creationDate: Optional[datetime]
 
     def to_dict(self) -> dict:
         return {

--- a/backend/sources/tests/unit/test_routers/test_entry_router.py
+++ b/backend/sources/tests/unit/test_routers/test_entry_router.py
@@ -121,6 +121,7 @@ class TestEntryRouterNotAuthenticated(unittest.TestCase):
             **response.json()
         )
         self.assertEqual(entry.answerId, returned_id)
+        self.assertIsNotNone(entry.creationDate)
 
     def test_submit_new_entry_and_delete_it(self):
         """

--- a/backend/sources/tests/unit/test_routers/test_form_router.py
+++ b/backend/sources/tests/unit/test_routers/test_form_router.py
@@ -82,6 +82,7 @@ class TestFormEndpointNoAuthChecks(unittest.TestCase):
         )
 
         self.assertEqual(extracted_form.formId, form_id)
+        self.assertIsNotNone(extracted_form.creationDate)
 
     def test_list_endpoint(self):
         """

--- a/frontend/src/api/inference/infer.ts
+++ b/frontend/src/api/inference/infer.ts
@@ -3,6 +3,7 @@ import { FormAnswers } from "../models";
 interface RawFormAnswer
 {
   answerId: string
+  creationDate: string
   formId: string
   authorEmail: string
   answers: string[]
@@ -30,6 +31,7 @@ export const Infer = async(formData: any):
         formId: fa.formId,
         answerId: fa.answerId,
         authorEmail: fa.authorEmail,
+        creationDate: fa.creationDate,
         answers: fa.answers.map(stuff => {
           return {content: stuff}
         })

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -16,6 +16,7 @@ export type SingleQAnswer = TextAnswer | MultipleChoiceAnswer
 export interface FormAnswers
 {
   formId: string
+  creationDate: string
   answerId: string
   authorEmail: string
   answers: SingleQAnswer[]


### PR DESCRIPTION
Add a datetime field to entries and forms.
The field is optional, so it shouldn't have any conflicts with the client, but @Rpd-Strike please confirm it is ok.

This closes #57 